### PR TITLE
Add ability to choose the number of winners per round.

### DIFF
--- a/css/raffle.css
+++ b/css/raffle.css
@@ -49,8 +49,8 @@ textarea {
 	overflow: hidden;
 }
 
-input[type="checkbox"] {
-	margin: 5px none;
+input[type="checkbox"], input[type="number"] {
+	margin: 0 10px 10px 0;
 }
 
 button {

--- a/index.html
+++ b/index.html
@@ -13,9 +13,10 @@
 		<span>Participants:<b id="participant-number"></b></span>
 	</div>
 	<div class='enter-names'>
-		<p>Enter names separated by new lines:</p>
+		<p>Enter names separated by newlines:</p>
 		<textarea class='name-text-field'></textarea>
-		<input id="remove-winners-input" type="checkbox" onclick="toggleRemoveWinners();" checked="checked"/><label for="remove-winners-input">Remove winners after drawing</label>
+        <div><input id="remove-winners-input" type="checkbox" onclick="toggleRemoveWinners();" checked="checked"/><label for="remove-winners-input">Remove winners after drawing</label></div>
+        <div><input id="number-of-winners-input" type="number" value="1" min="1" max="999" required/><label for="number-of-winners-input">Number of winners per drawing</label></div>
 		<button onclick="process();">Import</button>
 	</div>
 </body>

--- a/js/raffle.js
+++ b/js/raffle.js
@@ -32,12 +32,22 @@ function getNames() {
 	});
 }
 
+var numberOfWinnersPerRound = 1;
+
 function process(){
-	var names = $('.name-text-field').val().split('\n');
+	var names = getNames();
 	imported = [];
-	map(getNames(), function(name){
+	map(names, function(name){
 		imported.push({'name':name});
-	});
+    });
+    
+    var numFromInput = parseInt($('#number-of-winners-input').val(), 10);
+    if (isNaN(numFromInput) || numFromInput < 1) {
+        numberOfWinnersPerRound = 1;
+    } else {
+        numberOfWinnersPerRound = Math.min(numFromInput, names.length);
+    }
+
 	$('.enter-names').hide(500, function(){
 		makeTicketsWithPoints();
 	});
@@ -117,7 +127,7 @@ function Ticket(name, points){
 			})
 			setTimeout(function() {
 				callback();
-			}, length == 2 ? 1000 : 3000/length);
+			}, length == 2 ? 1000 : 3000/(length - numberOfWinnersPerRound));
 		}
 	}
 }
@@ -172,7 +182,14 @@ var makeTicketsWithPoints = function(){
 			t.dom.appendTo($('body'));
 			tickets.push(t);
 		}
-	});
+    });
+
+    $('#participant-number').css('width', '').text(tickets.length);
+    
+    if (tickets.length < 1) {
+        return;
+    }
+
 	tickets.reverse();
 	size = 40;
 	$('.ticket').css('font-size', size + 'px');
@@ -181,7 +198,6 @@ var makeTicketsWithPoints = function(){
 		$('.ticket').css('font-size', size + 'px');
 	}
 
-	$('#participant-number').css('width', '').text(tickets.length);
 	setTimeout(function() {
 		map(tickets, function(ticket){
 			ticket.fixPosition();
@@ -218,35 +234,50 @@ var pickName = function(){
 	$('body').unbind('click');
 	
 	var choices = getChoices();
-	if(remainingParticipants() > 1){
+	if(remainingParticipants() > numberOfWinnersPerRound){
 		var remove = randomInt(choices.length);
 		choices[remove].decrement(choices.length, function(){
 			pickName();
 		});
 	} else {
 		if (removeWinners) {
-			var winner = choices[0].name;
-			for (var entry of imported) {
-				if (entry.name == winner) {
-					entry.points--;
-				}
-			}
-		}
-		choices = $(choices[0].dom);
-		var top = choices.css('top');
-		var left = choices.css('left');
-		var fontsize = choices.css('font-size');
-		var width = choices.width();
-		choices.click(function(){
-			inProgress = false;
-			choices.animate({'font-size':fontsize,'top':top,'left':left},'slow');
-			$('.ticket').show(500).unbind('click');
-			setTimeout(function(){
-				makeTicketsWithPoints();
-			}, 700);
-		});
-		choices.animate({'font-size':3*size +'px','top':(window.innerHeight/5) + 'px','left':(window.innerWidth/2 - width) + 'px'},1500, function(){
-			choices.animate({'left':(window.innerWidth/2 - choices.width()/2) + 'px'}, 'slow');
-		});
+            choices.forEach(choice => {
+                var winner = choice.name;
+                for (var entry of imported) {
+                    if (entry.name == winner) {
+                        entry.points--;
+                    }
+                }
+            });
+        }
+        
+        if (numberOfWinnersPerRound == 1) {
+            choices = $(choices[0].dom);
+            var top = choices.css('top');
+            var left = choices.css('left');
+            var fontsize = choices.css('font-size');
+            var width = choices.width();
+            choices.click(function(){
+                inProgress = false;
+                choices.animate({'font-size':fontsize,'top':top,'left':left},'slow');
+                $('.ticket').show(500).unbind('click');
+                setTimeout(function(){
+                    makeTicketsWithPoints();
+                }, 700);
+            });
+            choices.animate({'font-size':3*size +'px','top':(window.innerHeight/5) + 'px','left':(window.innerWidth/2 - width) + 'px'},1500, function(){
+                choices.animate({'left':(window.innerWidth/2 - choices.width()/2) + 'px'}, 'slow');
+            });
+        } else {
+            choices.forEach(c => {
+                $(c.dom).animate({
+                    'font-size':1.25*size,
+                });
+                $(c.dom).css('background', '#EE8800');
+            });
+            $('body').click(() => {
+                makeTicketsWithPoints();
+            });
+        }
 	}
 }


### PR DESCRIPTION
Instead of reintroducing the `?limit=` query parameter, I've created a spinner in the UI when importing names that allows you to pick how many winners are chosen per round. If the value = 1, the raffle behaves the same as before. If the value > 1, the animation to show winners is slightly different (I leveraged the `window.limit` code that used to exist [here](https://github.com/stringham/stringham.github.io/commit/8bdd4adb602386195ffe3774d50da00945fc22a0)).
![Screen Shot 2020-10-13 at 5 30 49 PM](https://user-images.githubusercontent.com/8701983/95926642-02424200-0d7a-11eb-9f9e-9b1f35d90e07.jpg)
